### PR TITLE
Align article style and add media support

### DIFF
--- a/Articles/article1.html
+++ b/Articles/article1.html
@@ -2,26 +2,55 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Article 1 - The Future of Renewable Energy</title>
+    <title>The Future of Renewable Energy</title>
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="icon" href="https://upload.wikimedia.org/wikipedia/commons/3/3a/Wind_turbine_icon.svg" type="image/svg+xml">
 </head>
-<body class="article-bg">
+<body class="article-bg article1-bg">
     <nav class="tab-navigation">
       <div class="container">
         <div class="tab-nav">
           <a href="../index.html" class="tab-btn">Overview</a>
           <a href="../index.html#research" class="tab-btn">Research</a>
-          <a href="../blog.html" class="tab-btn active">Blog</a>
+          <a href="../blog.html" class="tab-btn active">Blog<span id="blog-colon" style="display:none;">:</span> <span id="policy-desk-tab-text" class="gradient-text"></span></a>
         </div>
       </div>
     </nav>
-    <article>
-        <img class="article-image" src="../Images/image1.jpg" alt="Renewable Energy">
+    <div class="article-overlay">
         <h1 class="article-title">The Future of Renewable Energy</h1>
+        <figure>
+            <img class="article-img" src="../Images/image1.jpg" alt="Renewable Energy">
+        </figure>
         <p class="article-description"><mark>Exploring how renewable energy sources are shaping the future of global power generation and sustainability.</mark></p>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vitae velit ex. Mauris dapibus risus quis suscipit vulputate.</p>
-    </article>
+    </div>
+    <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      const tabText = document.getElementById('policy-desk-tab-text');
+      const blogColon = document.getElementById('blog-colon');
+      const fullText = "The Policy Desk";
+      let current = "";
+      let i = 0;
+
+      tabText.style.opacity = 0;
+
+      function typeWriter() {
+        if (i === 0) {
+          tabText.style.opacity = 1;
+        }
+        if (i < fullText.length) {
+          current += fullText.charAt(i);
+          tabText.textContent = current;
+          i++;
+          setTimeout(typeWriter, 60);
+        } else {
+          blogColon.style.display = '';
+        }
+      }
+
+      setTimeout(typeWriter, 400);
+    });
+    </script>
 </body>
-</html> 
+</html>

--- a/Articles/article2.html
+++ b/Articles/article2.html
@@ -20,11 +20,17 @@
     </nav>
     <div class="article-overlay">
         <h1 class="article-title">Rades Power Station: A Glimpse Into Tunisia’s Energy Bottlenecks</h1>
+        <figure>
+            <img class="article-img" src="https://via.placeholder.com/800x400.png?text=Image+Placeholder" alt="Article image placeholder">
+        </figure>
         <p>At the edge of the Gulf of Tunis, the Rades power station looms as both a symbol of Tunisia’s industrial backbone and a warning sign of its stalled energy transition. As the country’s largest thermal generation complex, Rades I and II account for nearly 20% of Tunisia’s electricity production. Powered by imported natural gas, the station is emblematic of Tunisia’s energy paradox: a country with vast renewable potential that remains structurally dependent on fossil fuel infrastructure built decades ago.</p>
         <p>Commissioned in phases since the 1980s, the Rades complex is run by the state utility STEG (Société Tunisienne de l’Électricité et du Gaz). Rades C, the latest expansion — a 450 MW combined-cycle plant backed by Japanese financing — was meant to modernize the site and improve efficiency. Yet persistent grid fragility, fuel supply volatility, and water cooling demands continue to expose the system’s vulnerabilities.</p>
         <p>The station’s cooling technology draws heavily on seawater, making it energy-intensive and sensitive to marine environmental shifts. In the context of growing water scarcity and climate-related temperature stress, Rades’ reliance on water-intensive thermal generation reveals a structural blind spot. While desalination is being explored for water security, energy planners have yet to account for water risk within electricity production planning — an oversight with long-term consequences.</p>
         <p>Behind the technical profile lies an institutional story. Despite Tunisia’s formal commitment to decarbonization, Rades continues to receive priority maintenance and planning attention, while renewable integration projects face delays and fragmented oversight. It is not simply a matter of technology. The dominance of STEG and a path-dependent investment logic favoring large-scale gas plants like Rades have slowed the momentum for decentralized renewable uptake.</p>
         <p>Private investors observe this pattern with caution. The system's prioritization of centralized fossil infrastructure reinforces skepticism about the grid’s readiness to accommodate intermittent solar and wind sources — despite Tunisia’s 300+ sunny days a year. As long as Rades remains a keystone in Tunisia’s energy system, its operational structure will shape investor perceptions of risk and government commitment.</p>
+        <figure>
+            <img class="graph-img" src="https://via.placeholder.com/800x400.png?text=Graph+Placeholder" alt="Graph placeholder">
+        </figure>
         <p>The energy transition will not succeed through targets alone. What happens at Rades — whether it is retrofitted, replaced, or reimagined — will define not only Tunisia’s emissions trajectory, but also its credibility as a market for sustainable energy investment.</p>
     </div>
     <script>

--- a/Articles/article3.html
+++ b/Articles/article3.html
@@ -2,26 +2,55 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Article 3 - Water-Energy Nexus in the Mediterranean</title>
+    <title>Water-Energy Nexus in the Mediterranean</title>
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="icon" href="https://upload.wikimedia.org/wikipedia/commons/3/3a/Wind_turbine_icon.svg" type="image/svg+xml">
 </head>
-<body class="article-bg">
+<body class="article-bg article3-bg">
     <nav class="tab-navigation">
       <div class="container">
         <div class="tab-nav">
           <a href="../index.html" class="tab-btn">Overview</a>
           <a href="../index.html#research" class="tab-btn">Research</a>
-          <a href="../blog.html" class="tab-btn active">Blog</a>
+          <a href="../blog.html" class="tab-btn active">Blog<span id="blog-colon" style="display:none;">:</span> <span id="policy-desk-tab-text" class="gradient-text"></span></a>
         </div>
       </div>
     </nav>
-    <article>
-        <img class="article-image" src="../Images/image3.jpg" alt="Water-Energy Nexus">
+    <div class="article-overlay">
         <h1 class="article-title">Water-Energy Nexus in the Mediterranean</h1>
+        <figure>
+            <img class="article-img" src="../Images/image3.jpg" alt="Water-Energy Nexus">
+        </figure>
         <p class="article-description"><mark>Highlighting the critical interdependence of water and energy resources in arid Mediterranean regions.</mark></p>
         <p>Praesent euismod, justo vel consectetur cursus, enim erat dictum urna, eget facilisis erat elit id massa.</p>
-    </article>
+    </div>
+    <script>
+    document.addEventListener("DOMContentLoaded", function() {
+      const tabText = document.getElementById('policy-desk-tab-text');
+      const blogColon = document.getElementById('blog-colon');
+      const fullText = "The Policy Desk";
+      let current = "";
+      let i = 0;
+
+      tabText.style.opacity = 0;
+
+      function typeWriter() {
+        if (i === 0) {
+          tabText.style.opacity = 1;
+        }
+        if (i < fullText.length) {
+          current += fullText.charAt(i);
+          tabText.textContent = current;
+          i++;
+          setTimeout(typeWriter, 60);
+        } else {
+          blogColon.style.display = '';
+        }
+      }
+
+      setTimeout(typeWriter, 400);
+    });
+    </script>
 </body>
-</html> 
+</html>

--- a/styles.css
+++ b/styles.css
@@ -702,6 +702,12 @@ body {
 .article2-bg {
     background-image: url('Images/image2.jpg');
 }
+.article1-bg {
+    background-image: url('Images/image1.jpg');
+}
+.article3-bg {
+    background-image: url('Images/image3.jpg');
+}
 
 .article-bg::before {
     content: "";
@@ -723,6 +729,15 @@ body {
     position: relative;
     top: 60px;
     z-index: 2;
+}
+
+.article-img,
+.graph-img {
+    width: 100%;
+    height: auto;
+    display: block;
+    margin: 24px 0;
+    border-radius: 8px;
 }
 
 @media (max-width: 800px) {


### PR DESCRIPTION
## Summary
- unify article pages so they share the article 2 layout
- add placeholder image and graph support to article 2
- update article 1 and article 3 using the new layout
- extend styles for article backgrounds and media elements

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68813695e6748324b200822db63019ad