### PR TITLE
Fix overview tab not resetting scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,10 @@
 // Tab functionality
 document.addEventListener('DOMContentLoaded', function() {
+    // Disable automatic scroll restoration across navigations
+    if ('scrollRestoration' in history) {
+        history.scrollRestoration = 'manual';
+    }
+
     const tabButtons = document.querySelectorAll('.tab-btn');
     const tabContents = document.querySelectorAll('.tab-content');
 
@@ -28,12 +33,12 @@ document.addEventListener('DOMContentLoaded', function() {
             location.hash = `#${targetTab}`;
         }
 
-        // Smooth scroll the main content area to the top
-        // const mainContentArea = document.querySelector('.main-content-area');
-        // if (mainContentArea) {
-        //     mainContentArea.scrollTo({ top: 0, behavior: 'smooth' });
-        // }
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+        // Smooth scroll the main content area and window to the top
+        const mainContentArea = document.querySelector('.main-content-area');
+        if (mainContentArea) {
+            mainContentArea.scrollTo({ top: 0, behavior: 'auto' });
+        }
+        window.scrollTo({ top: 0, behavior: 'auto' });
     }
 
     // Add click event listeners to tab buttons
@@ -179,6 +184,10 @@ document.addEventListener('DOMContentLoaded', function() {
 window.addEventListener('load', function() {
     document.body.classList.add('loaded');
     // Ensure page starts at the top even when using anchors
+    const mainContentArea = document.querySelector('.main-content-area');
+    if (mainContentArea) {
+        mainContentArea.scrollTop = 0;
+    }
     window.scrollTo(0, 0);
 });
 


### PR DESCRIPTION
## Summary
- reset scroll restoration
- ensure main content area scrolls to top when changing tabs or on page load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883967faa988324ac7f84f3deb17d40