### PR TITLE
Apply Roboto Serif to navigation

### DIFF
--- a/data.html
+++ b/data.html
@@ -7,6 +7,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:ital,opsz,wght@0,8..144,100..900;1,8..144,100..900&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="icon" href="https://upload.wikimedia.org/wikipedia/commons/3/3a/Wind_turbine_icon.svg" type="image/svg+xml">
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Serif:ital,opsz,wght@0,8..144,100..900;1,8..144,100..900&display=swap" rel="stylesheet">
 </head>
 <body>
     <!-- Tab Navigation -->

--- a/styles.css
+++ b/styles.css
@@ -84,7 +84,7 @@ body {
     transition: all 0.2s ease;
     white-space: nowrap;
     position: relative;
-    font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    font-family: 'Roboto Serif', Arial, serif;
     letter-spacing: 0.01em;
     text-decoration: none !important;
     border-bottom: none !important;


### PR DESCRIPTION
## Summary
- use Roboto Serif for navigation buttons
- load Roboto Serif font on pages with the main navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883a3c1c33083248ab0f52dd47dbb10