### PR TITLE
Improve overview layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,9 @@
                     <div class="profile-section">
                         <div class="profile-box">
                             <img src="Images/Headshot2.PNG" alt="Houssem Chammam" class="profile-img">
+                            <p class="profile-name-side"><strong>Houssem Chammam</strong></p>
                             <p class="profile-role">Public Policy Analyst</p>
-                            <p class="profile-location">Berlin &amp; Tunis</p>
+                            <p class="profile-location"><small>Tunis &amp; Berlin</small></p>
                             <a href="mailto:chammam.houssem@gmail.com" class="profile-email">
                                 <i class="fas fa-envelope"></i> chammam.houssem@gmail.com
                             </a>
@@ -78,31 +79,6 @@
                                 <span>Read more</span>
                                 <i class="fas fa-chevron-down"></i>
                             </button>
-                        </div>
-
-                        <!-- Skills/Methods Section -->
-                        <div class="skills-grid">
-                            <div class="skill-item">
-                                <div class="skill-icon">
-                                    <i class="fas fa-layer-group"></i>
-                                </div>
-                                <h3>Mixed Methods</h3>
-                                <p>Blending quantitative & qualitative research for practical policy solutions.</p>
-                            </div>
-                            <div class="skill-item">
-                                <div class="skill-icon">
-                                    <i class="fas fa-chart-line"></i>
-                                </div>
-                                <h3>Data-Driven Analysis</h3>
-                                <p>Transforming data and evidence into actionable policy advice.</p>
-                            </div>
-                            <div class="skill-item">
-                                <div class="skill-icon">
-                                    <i class="fas fa-bullhorn"></i>
-                                </div>
-                                <h3>Advocacy for Impact</h3>
-                                <p>Strategic engagement to drive sustainable policy change.</p>
-                            </div>
                         </div>
 
                         <!-- Experience Timeline -->
@@ -140,6 +116,55 @@
                                         <p class="timeline-meta">Bernie Sanders 2020 • Minnesota, USA</p>
                                         <p>Led local campaign operations, policy messaging, and volunteer coordination. Contributed to a winning strategy grounded in the Green New Deal and social justice themes.</p>
                                     </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Skills/Methods Section -->
+                        <div class="skills-grid">
+                            <div class="skill-item">
+                                <div class="skill-icon">
+                                    <i class="fas fa-layer-group"></i>
+                                </div>
+                                <h3>Mixed Methods</h3>
+                                <p>Blending quantitative &amp; qualitative research for practical policy solutions.</p>
+                                <button class="read-more-btn skill-read-more">Read more</button>
+                                <div class="skill-details hidden">
+                                    <ul>
+                                        <li>Placeholder bullet 1</li>
+                                        <li>Placeholder bullet 2</li>
+                                    </ul>
+                                    <button class="read-less-btn skill-read-less">Read Less</button>
+                                </div>
+                            </div>
+                            <div class="skill-item">
+                                <div class="skill-icon">
+                                    <i class="fas fa-chart-line"></i>
+                                </div>
+                                <h3>Data-Driven Analysis</h3>
+                                <p>Transforming data and evidence into actionable policy advice.</p>
+                                <button class="read-more-btn skill-read-more">Read more</button>
+                                <div class="skill-details hidden">
+                                    <ul>
+                                        <li>Placeholder bullet 1</li>
+                                        <li>Placeholder bullet 2</li>
+                                    </ul>
+                                    <button class="read-less-btn skill-read-less">Read Less</button>
+                                </div>
+                            </div>
+                            <div class="skill-item">
+                                <div class="skill-icon">
+                                    <i class="fas fa-bullhorn"></i>
+                                </div>
+                                <h3>Advocacy for Impact</h3>
+                                <p>Strategic engagement to drive sustainable policy change.</p>
+                                <button class="read-more-btn skill-read-more">Read more</button>
+                                <div class="skill-details hidden">
+                                    <ul>
+                                        <li>Placeholder bullet 1</li>
+                                        <li>Placeholder bullet 2</li>
+                                    </ul>
+                                    <button class="read-less-btn skill-read-less">Read Less</button>
                                 </div>
                             </div>
                         </div>

--- a/script.js
+++ b/script.js
@@ -426,3 +426,41 @@ window.onload = function() {
   initGDPShareChart();
 };
 
+// Skill details toggle on overview page
+document.addEventListener('DOMContentLoaded', function() {
+  const skillItems = document.querySelectorAll('.skill-item');
+  skillItems.forEach(item => {
+    const details = item.querySelector('.skill-details');
+    const readMore = item.querySelector('.skill-read-more');
+    const readLess = item.querySelector('.skill-read-less');
+    if (!details) return;
+
+    function openDetails() {
+      details.classList.remove('hidden');
+    }
+
+    function closeDetails() {
+      details.classList.add('hidden');
+    }
+
+    item.addEventListener('click', e => {
+      if (e.target === readLess || details.contains(e.target)) return;
+      openDetails();
+    });
+
+    if (readMore) {
+      readMore.addEventListener('click', e => {
+        e.stopPropagation();
+        openDetails();
+      });
+    }
+
+    if (readLess) {
+      readLess.addEventListener('click', e => {
+        e.stopPropagation();
+        closeDetails();
+      });
+    }
+  });
+});
+

--- a/styles.css
+++ b/styles.css
@@ -146,6 +146,13 @@ body {
     margin: 0 auto;
 }
 
+.profile-name-side {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1a365d;
+    margin-top: 10px;
+}
+
 .profile-role {
     font-size: 18px;
     font-weight: 600;
@@ -385,6 +392,39 @@ body {
     font-size: 14px;
     color: #6c757d;
     line-height: 1.5;
+}
+
+.skill-details {
+    text-align: left;
+    margin-top: 12px;
+}
+
+.skill-details ul {
+    padding-left: 20px;
+    margin-bottom: 12px;
+}
+
+.skill-details li {
+    font-size: 14px;
+    color: #495057;
+    line-height: 1.6;
+}
+
+.read-less-btn {
+    background: none;
+    border: 1px solid #e9ecef;
+    color: #6c757d;
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.2s ease;
+}
+
+.read-less-btn:hover {
+    background-color: #f8f9fa;
+    border-color: #007bff;
+    color: #007bff;
 }
 
 /* Timeline */


### PR DESCRIPTION
## Summary
- show name, role, and location below the profile image
- move the skills section below Experience
- add expandable bullet lists for skills with Read More/Less buttons
- style new sidebar text and skill details
- support skill detail toggling in script

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883ae1313b083248b1ef3e69d974daf