### PR TITLE
Update Legality article to use local image

### DIFF
--- a/Articles/article4.html
+++ b/Articles/article4.html
@@ -79,7 +79,7 @@
         <div class="container">
             <article class="article-content">
                 <figure class="article-featured-image">
-                    <img src="https://images.unsplash.com/photo-1737233338996-a9f8beb1b30c?auto=format&fit=clamp&w=2087&h=1329&q=80&sat=-100&blend=112d3f&blend-mode=screen&sat=-100" alt="Digital governance interface illustrating lawful AI infrastructure" class="featured-img">
+                    <img src="../Images/Legality.png" alt="Digital governance interface illustrating lawful AI infrastructure" class="featured-img">
                     <figcaption>Agentic browsers need authoritative, machine-readable signals to act lawfully.</figcaption>
                 </figure>
 

--- a/blog.html
+++ b/blog.html
@@ -58,7 +58,7 @@
         <!-- Blog Post 2 -->
         <a href="Articles/article4.html" class="news-item-link">
           <div class="news-item" style="background: #fff; border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); overflow: hidden;">
-            <img src="https://images.unsplash.com/photo-1737233338996-a9f8beb1b30c?auto=format&fit=clamp&w=2087&h=1329&q=80&sat=-100&blend=112d3f&blend-mode=screen&sat=-100" alt="Digital governance interface illustrating lawful AI infrastructure" style="width:100%; height:180px; object-fit:cover;">
+            <img src="Images/Legality.png" alt="Digital governance interface illustrating lawful AI infrastructure" style="width:100%; height:180px; object-fit:cover;">
             <div style="padding: 24px 24px 12px;">
               <div class="news-date">December 11, 2025 • 10 min read</div>
               <h3 style="font-size: 22px; font-weight: bold; margin: 12px 0;">Legality is Not a Dataset: AI Lawfulness as an Infrastructure Problem</h3>


### PR DESCRIPTION
## Summary
- replace the Legality article feature image with the local Images/Legality.png asset
- update the blog listing card to use the same local image

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c56cf33808324a031eebebed37a2a)